### PR TITLE
Add TradingView strategy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# -01
+# -01 Repository
+
+This repository contains various resources. A new TradingView strategy example is provided in the `strategies` folder.
+
+## Contents
+- `strategies/high_profit_strategy.pine`: A sample TradingView strategy demonstrating a simple moving average crossover system with configurable risk management settings.

--- a/strategies/high_profit_strategy.pine
+++ b/strategies/high_profit_strategy.pine
@@ -1,0 +1,36 @@
+//@version=5
+strategy("High Profit Low Drawdown Strategy", overlay=true, initial_capital=10000, default_qty_type=strategy.percent_of_equity, default_qty_value=10)
+
+// Input parameters
+fastLen = input.int(9, "Fast MA Length", minval=1)
+slowLen = input.int(21, "Slow MA Length", minval=1)
+stopLossPerc = input.float(1.0, "Stop Loss %", minval=0.1)
+takeProfitPerc = input.float(2.0, "Take Profit %", minval=0.1)
+
+// Moving averages
+fastMA = ta.ema(close, fastLen)
+slowMA = ta.ema(close, slowLen)
+
+// Entry conditions
+longCond = ta.crossover(fastMA, slowMA)
+shortCond = ta.crossunder(fastMA, slowMA)
+
+// Plot moving averages
+plot(fastMA, color=color.blue, title="Fast MA")
+plot(slowMA, color=color.orange, title="Slow MA")
+
+// Execute trades
+if longCond
+    strategy.entry("Long", strategy.long)
+if shortCond
+    strategy.entry("Short", strategy.short)
+
+// Risk management
+if strategy.position_size > 0
+    strategy.exit("TP/SL Long", "Long", stop=strategy.position_avg_price * (1 - stopLossPerc / 100), limit=strategy.position_avg_price * (1 + takeProfitPerc / 100))
+if strategy.position_size < 0
+    strategy.exit("TP/SL Short", "Short", stop=strategy.position_avg_price * (1 + stopLossPerc / 100), limit=strategy.position_avg_price * (1 - takeProfitPerc / 100))
+
+// Plot trade direction on chart
+plotshape(longCond, title="Long Signal", location=location.belowbar, color=color.green, style=shape.arrowup, size=size.tiny)
+plotshape(shortCond, title="Short Signal", location=location.abovebar, color=color.red, style=shape.arrowdown, size=size.tiny)


### PR DESCRIPTION
## Summary
- add a sample TradingView strategy script
- update README with info about the new script

## Testing
- `pytest -q`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c4504d0c88321b71ad95988f91214